### PR TITLE
Update plot_wingbox.py

### DIFF
--- a/openaerostruct/utils/plot_wingbox.py
+++ b/openaerostruct/utils/plot_wingbox.py
@@ -64,7 +64,7 @@ class Display(object):
         self.canvas._tkcanvas.pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
         self.ax = plt.subplot2grid((5, 8), (0, 0), rowspan=5,
                                    colspan=4, projection='3d')
-        self.ax.set_aspect('equal')
+        #self.ax.set_aspect('equal')
 
         self.num_iters = 0
         self.show_wing = True


### PR DESCRIPTION
Commented out line 67
self.ax.set_aspect('equal')
when running plot_wingbox aerostruct.db as recommended in the wingbox_mpt_Q400_example.py file this would cause an error.

Traceback (most recent call last):
  File "C:\Users\EricMarc-Aurele\Anaconda3\Scripts\plot_wingbox-script.py", line 11, in <module>
    load_entry_point('openaerostruct', 'console_scripts', 'plot_wingbox')()
  File "c:\users\ericmarc-aurele\openaerostruct\openaerostruct\utils\plot_wingbox.py", line 900, in disp_plot
    disp = Display(args)
  File "c:\users\ericmarc-aurele\openaerostruct\openaerostruct\utils\plot_wingbox.py", line 67, in __init__
    self.ax.set_aspect('equal')
  File "c:\users\ericmarc-aurele\anaconda3\lib\site-packages\matplotlib\axes\_base.py", line 1281, in set_aspect
    'It is not currently possible to manually set the aspect '
NotImplementedError: It is not currently possible to manually set the aspect on 3D axes

Commenting the line allows the wing box optimization to be displayed.

I have NOT done testing to determine if this will cause problems elsewhere.

## Purpose
Allow users to have plot_wingbox function as expected with wingbox_mpt_Q400_example.py example.

## Type of change
-Bugfix

## Testing
Run wingbox_mpt_Q400_example.py
Run plot_wingbox aerostruct.db in directory with wingbox_mpt_Q400_example.py
Wingbox plot displays

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
